### PR TITLE
Wrapping graphics

### DIFF
--- a/src/game.rs
+++ b/src/game.rs
@@ -62,7 +62,7 @@ impl Config {
             delta_t: 1.0 / 60.0,
             field_size: Vec2D {
                 x: 1280.0,
-                y: 720.0,
+                y: 820.0,
             },
             key_binds: DEFAULT_KEYBINDS.to_vec(),
         }

--- a/src/render_path.rs
+++ b/src/render_path.rs
@@ -305,16 +305,13 @@ fn render_score(buf: &mut String, mut score: u64, field_size: &Vec2D) {
     const DIGIT_STEP: f64 = -3.0;
     const DIGIT_RIGHTMOST: f64 = 120.0;
     for (idx, d) in digits.iter().enumerate() {
-        let digit = VECTOR_DIGITS[*d as usize];
+        let digit = VECTOR_DIGITS[*d as usize].to_vec();
         let offset = Vec2D {
             x: DIGIT_RIGHTMOST + (idx as f64) * DIGIT_STEP,
             y: 5.0,
-        };
-        let points = digit
-            .iter()
-            .map(|&p| (p + offset).scale(DIGIT_SCALE))
-            .collect();
-        draw_points_wrapping(buf, &points, field_size);
+        }
+        .scale(DIGIT_SCALE);
+        draw_object(buf, &digit, DIGIT_SCALE, 0.0, &offset, field_size);
     }
 }
 

--- a/src/render_path.rs
+++ b/src/render_path.rs
@@ -307,7 +307,7 @@ fn render_score(buf: &mut String, mut score: u64) {
     for (idx, d) in digits.iter().enumerate() {
         let digit = VECTOR_DIGITS[*d as usize];
         for (i, p) in digit.iter().enumerate() {
-            let p = Vec2D { x: p.x, y: p.y }.scale(DIGIT_SCALE)
+            let p = p.scale(DIGIT_SCALE)
                 + Vec2D {
                     x: DIGIT_RIGHTMOST + (idx as f64) * DIGIT_STEP,
                     y: DIGIT_SCALE * 5.0,

--- a/src/render_path.rs
+++ b/src/render_path.rs
@@ -53,25 +53,16 @@ fn render_ship(buf: &mut String, game: &Game) {
     if ship.dead {
         return;
     }
+    draw_object(buf, SHIP_POINTS.to_vec(), 2.0, ship.angle, ship.pos);
     let inputs = &game.inputs;
-    for (i, p) in SHIP_POINTS.iter().enumerate() {
-        let p_c = p.scale(2.0).rotate(ship.angle) + ship.pos;
-        draw(buf, i != 0, p_c);
-    }
     if inputs.is_down(InputIndex::Forward) || inputs.is_down(InputIndex::Backward) {
-        for (i, p) in FLARE.iter().enumerate() {
-            let p_c = p.scale(2.0).rotate(ship.angle) + ship.pos;
-            draw(buf, i != 0, p_c);
-        }
+        draw_object(buf, FLARE.to_vec(), 2.0, ship.angle, ship.pos);
     }
 }
 
 fn render_bullet(buf: &mut String, bullet: &Bullet) {
-    let offset = Vec2D::zero();
-    let start = bullet.pos + offset;
-    let end = bullet.pos + bullet.speed.normalize().scale(5.0);
-    draw(buf, false, start);
-    draw(buf, true, end);
+    let tail = bullet.pos + bullet.speed.normalize().scale(5.0);
+    draw_points(buf, vec![bullet.pos, tail]);
 }
 
 fn render_asteroid(buf: &mut String, asteroid: &Asteroid) {

--- a/src/render_path.rs
+++ b/src/render_path.rs
@@ -306,15 +306,15 @@ fn render_score(buf: &mut String, mut score: u64) {
     const DIGIT_RIGHTMOST: f64 = 120.0;
     for (idx, d) in digits.iter().enumerate() {
         let digit = VECTOR_DIGITS[*d as usize];
-        for (i, p) in digit.iter().enumerate() {
-            let p = (*p
-                + Vec2D {
-                    x: DIGIT_RIGHTMOST + (idx as f64) * DIGIT_STEP,
-                    y: 5.0,
-                })
-            .scale(DIGIT_SCALE);
-            draw(buf, i != 0, &p);
-        }
+        let offset = Vec2D {
+            x: DIGIT_RIGHTMOST + (idx as f64) * DIGIT_STEP,
+            y: 5.0,
+        };
+        let points = digit
+            .iter()
+            .map(|&p| (p + offset).scale(DIGIT_SCALE))
+            .collect();
+        draw_points(buf, &points);
     }
 }
 

--- a/src/render_path.rs
+++ b/src/render_path.rs
@@ -23,6 +23,10 @@ fn draw_points(buf: &mut String, points: Vec<Vec2D>, _field_size: Vec2D) {
     }
 }
 
+fn translate(points: &Vec<Vec2D>, translation: Vec2D) -> Vec<Vec2D> {
+    points.iter().map(|&point| point + translation).collect()
+}
+
 fn draw_points_wrapping(buf: &mut String, points: Vec<Vec2D>, _field_size: Vec2D) {
     let x_wrap = points
         .iter()
@@ -56,41 +60,32 @@ fn draw_points_wrapping(buf: &mut String, points: Vec<Vec2D>, _field_size: Vec2D
         .unwrap_or_default();
     if x_wrap != 0.0 {
         if y_wrap != 0.0 {
-            let translated_points = points
-                .iter()
-                .map(|&point| {
-                    point
-                        + Vec2D {
-                            x: _field_size.x * x_wrap,
-                            y: _field_size.y * y_wrap,
-                        }
-                })
-                .collect();
+            let translated_points = translate(
+                &points,
+                Vec2D {
+                    x: _field_size.x * x_wrap,
+                    y: _field_size.y * y_wrap,
+                },
+            );
             draw_points(buf, translated_points, _field_size);
         }
-        let translated_points = points
-            .iter()
-            .map(|&point| {
-                point
-                    + Vec2D {
-                        x: _field_size.x * x_wrap,
-                        y: 0.0,
-                    }
-            })
-            .collect();
+        let translated_points = translate(
+            &points,
+            Vec2D {
+                x: _field_size.x * x_wrap,
+                y: 0.0,
+            },
+        );
         draw_points(buf, translated_points, _field_size);
     }
     if y_wrap != 0.0 {
-        let translated_points = points
-            .iter()
-            .map(|&point| {
-                point
-                    + Vec2D {
-                        x: 0.0,
-                        y: _field_size.y * y_wrap,
-                    }
-            })
-            .collect();
+        let translated_points = translate(
+            &points,
+            Vec2D {
+                x: 0.0,
+                y: _field_size.y * y_wrap,
+            },
+        );
         draw_points(buf, translated_points, _field_size);
     }
     draw_points(buf, points, _field_size);

--- a/src/render_path.rs
+++ b/src/render_path.rs
@@ -13,6 +13,16 @@ fn draw(buf: &mut String, line: bool, point: Vec2D) {
     .expect("could not write string");
 }
 
+fn draw_points(buf: &mut String, points: Vec<Vec2D>) {
+    if (points.is_empty()) {
+        return;
+    }
+    draw(buf, false, points[0]);
+    for &point in &points[1..] {
+        draw(buf, true, point);
+    }
+}
+
 const SHIP_POINTS: &[Vec2D] = &[
     Vec2D { x: 10.0, y: 0.0 },
     Vec2D { x: -10.0, y: -5.0 },

--- a/src/render_path.rs
+++ b/src/render_path.rs
@@ -302,16 +302,17 @@ fn render_score(buf: &mut String, mut score: u64) {
         digits.push(0);
     }
     const DIGIT_SCALE: f64 = 10.0;
-    const DIGIT_STEP: f64 = -30.0;
-    const DIGIT_RIGHTMOST: f64 = 1200.0;
+    const DIGIT_STEP: f64 = -3.0;
+    const DIGIT_RIGHTMOST: f64 = 120.0;
     for (idx, d) in digits.iter().enumerate() {
         let digit = VECTOR_DIGITS[*d as usize];
         for (i, p) in digit.iter().enumerate() {
-            let p = p.scale(DIGIT_SCALE)
+            let p = (*p
                 + Vec2D {
                     x: DIGIT_RIGHTMOST + (idx as f64) * DIGIT_STEP,
-                    y: DIGIT_SCALE * 5.0,
-                };
+                    y: 5.0,
+                })
+            .scale(DIGIT_SCALE);
             draw(buf, i != 0, &p);
         }
     }

--- a/src/render_path.rs
+++ b/src/render_path.rs
@@ -14,7 +14,7 @@ fn draw(buf: &mut String, line: bool, point: Vec2D) {
 }
 
 fn draw_points(buf: &mut String, points: Vec<Vec2D>) {
-    if (points.is_empty()) {
+    if points.is_empty() {
         return;
     }
     draw(buf, false, points[0]);

--- a/src/render_path.rs
+++ b/src/render_path.rs
@@ -167,7 +167,7 @@ fn render_lives(buf: &mut String, lives: u64, field_size: &Vec2D) {
     const LIFE_STEP: f64 = 40.0;
     const UP_ANGLE: f64 = std::f64::consts::PI * -0.5;
     for l in 0..lives {
-        let y = -50.0;
+        let y = 50.0;
         let x = ((l + 1) as f64) * LIFE_STEP;
         draw_object(
             buf,
@@ -310,7 +310,7 @@ fn render_score(buf: &mut String, mut score: u64) {
             let p = Vec2D { x: p.x, y: p.y }.scale(DIGIT_SCALE)
                 + Vec2D {
                     x: DIGIT_RIGHTMOST + (idx as f64) * DIGIT_STEP,
-                    y: -DIGIT_SCALE * 5.0,
+                    y: DIGIT_SCALE * 5.0,
                 };
             draw(buf, i != 0, &p);
         }

--- a/src/render_path.rs
+++ b/src/render_path.rs
@@ -23,6 +23,79 @@ fn draw_points(buf: &mut String, points: Vec<Vec2D>, _field_size: Vec2D) {
     }
 }
 
+fn draw_points_wrapping(buf: &mut String, points: Vec<Vec2D>, _field_size: Vec2D) {
+    let x_wrap = points
+        .iter()
+        .map(|point| point.x)
+        .map(|x| {
+            if x >= _field_size.x {
+                -1.0
+            } else if x < _field_size.x {
+                1.0
+            } else {
+                0.0
+            }
+        })
+        .filter(|&wrap| wrap != 0.0)
+        .nth(0)
+        .unwrap_or_default();
+    let y_wrap = points
+        .iter()
+        .map(|point| point.y)
+        .map(|y| {
+            if y >= _field_size.y {
+                -1.0
+            } else if y < _field_size.y {
+                1.0
+            } else {
+                0.0
+            }
+        })
+        .filter(|&wrap| wrap != 0.0)
+        .nth(0)
+        .unwrap_or_default();
+    if x_wrap != 0.0 {
+        if y_wrap != 0.0 {
+            let translated_points = points
+                .iter()
+                .map(|&point| {
+                    point
+                        + Vec2D {
+                            x: _field_size.x * x_wrap,
+                            y: _field_size.y * y_wrap,
+                        }
+                })
+                .collect();
+            draw_points(buf, translated_points, _field_size);
+        }
+        let translated_points = points
+            .iter()
+            .map(|&point| {
+                point
+                    + Vec2D {
+                        x: _field_size.x * x_wrap,
+                        y: 0.0,
+                    }
+            })
+            .collect();
+        draw_points(buf, translated_points, _field_size);
+    }
+    if y_wrap != 0.0 {
+        let translated_points = points
+            .iter()
+            .map(|&point| {
+                point
+                    + Vec2D {
+                        x: 0.0,
+                        y: _field_size.y * y_wrap,
+                    }
+            })
+            .collect();
+        draw_points(buf, translated_points, _field_size);
+    }
+    draw_points(buf, points, _field_size);
+}
+
 fn draw_object(
     buf: &mut String,
     points: Vec<Vec2D>,

--- a/src/render_path.rs
+++ b/src/render_path.rs
@@ -26,7 +26,7 @@ mod internals {
         }
     }
 
-    fn calculate_wrap(points: &Vec<Vec2D>, field_size: &Vec2D, x: bool) -> f64 {
+    fn calculate_wrap(points: &[Vec2D], field_size: &Vec2D, x: bool) -> f64 {
         let field_size = if x { field_size.x } else { field_size.y };
         points
             .iter()
@@ -40,21 +40,21 @@ mod internals {
                     None
                 }
             })
-            .nth(0)
+            .next()
             .unwrap_or_default()
     }
 
-    fn translate(points: &Vec<Vec2D>, translation: &Vec2D) -> Vec<Vec2D> {
+    fn translate(points: &[Vec2D], translation: &Vec2D) -> Vec<Vec2D> {
         points.iter().map(|&point| point + *translation).collect()
     }
 
     pub fn draw_points_wrapping(buf: &mut String, points: &Vec<Vec2D>, field_size: &Vec2D) {
-        let x_wrap = calculate_wrap(&points, &field_size, true);
-        let y_wrap = calculate_wrap(&points, &field_size, false);
+        let x_wrap = calculate_wrap(points, field_size, true);
+        let y_wrap = calculate_wrap(points, field_size, false);
         if x_wrap != 0.0 {
             if y_wrap != 0.0 {
                 let translated_points = translate(
-                    &points,
+                    points,
                     &Vec2D {
                         x: field_size.x * x_wrap,
                         y: field_size.y * y_wrap,
@@ -63,7 +63,7 @@ mod internals {
                 draw_points(buf, &translated_points);
             }
             let translated_points = translate(
-                &points,
+                points,
                 &Vec2D {
                     x: field_size.x * x_wrap,
                     y: 0.0,
@@ -73,7 +73,7 @@ mod internals {
         }
         if y_wrap != 0.0 {
             let translated_points = translate(
-                &points,
+                points,
                 &Vec2D {
                     x: 0.0,
                     y: field_size.y * y_wrap,
@@ -86,7 +86,7 @@ mod internals {
 
     pub fn draw_object(
         buf: &mut String,
-        points: &Vec<Vec2D>,
+        points: &[Vec2D],
         scale: f64,
         rotation: f64,
         offset: &Vec2D,
@@ -126,7 +126,7 @@ fn render_ship(buf: &mut String, game: &Game) {
     }
     draw_object(
         buf,
-        &SHIP_POINTS.to_vec(),
+        SHIP_POINTS,
         2.0,
         ship.angle,
         &ship.pos,
@@ -136,7 +136,7 @@ fn render_ship(buf: &mut String, game: &Game) {
     if inputs.is_down(InputIndex::Forward) || inputs.is_down(InputIndex::Backward) {
         draw_object(
             buf,
-            &FLARE.to_vec(),
+            FLARE,
             2.0,
             ship.angle,
             &ship.pos,
@@ -157,7 +157,7 @@ fn render_asteroid(buf: &mut String, asteroid: &Asteroid, field_size: &Vec2D) {
         .iter()
         .enumerate()
         .map(|(i, v)| v.rotate(angle * (i as f64)))
-        .collect();
+        .collect::<Vec<_>>();
     draw_object(
         buf,
         &asteroid_points,
@@ -174,14 +174,7 @@ fn render_lives(buf: &mut String, lives: u64, field_size: &Vec2D) {
     for l in 0..lives {
         let y = 50.0;
         let x = ((l + 1) as f64) * LIFE_STEP;
-        draw_object(
-            buf,
-            &SHIP_POINTS.to_vec(),
-            2.0,
-            UP_ANGLE,
-            &Vec2D { x, y },
-            field_size,
-        );
+        draw_object(buf, SHIP_POINTS, 2.0, UP_ANGLE, &Vec2D { x, y }, field_size);
     }
 }
 

--- a/src/render_path.rs
+++ b/src/render_path.rs
@@ -292,7 +292,7 @@ const VECTOR_DIGITS: &[&[Vec2D]] = &[
     ],
 ];
 
-fn render_score(buf: &mut String, mut score: u64) {
+fn render_score(buf: &mut String, mut score: u64, field_size: &Vec2D) {
     let mut digits = Vec::new();
     while score > 0 {
         digits.push(score % 10);
@@ -314,7 +314,7 @@ fn render_score(buf: &mut String, mut score: u64) {
             .iter()
             .map(|&p| (p + offset).scale(DIGIT_SCALE))
             .collect();
-        draw_points(buf, &points);
+        draw_points_wrapping(buf, &points, field_size);
     }
 }
 
@@ -331,5 +331,5 @@ pub fn render_game(buf: &mut String, game: &Game) {
     for explosion in game.explosions.iter() {
         render_explosion(buf, explosion, game.tick, &field_size);
     }
-    render_score(buf, game.score);
+    render_score(buf, game.score, &field_size);
 }

--- a/src/render_path.rs
+++ b/src/render_path.rs
@@ -31,10 +31,10 @@ mod internals {
         points
             .iter()
             .map(|point| if x { point.x } else { point.y })
-            .filter_map(|x| {
-                if x >= field_size {
+            .filter_map(|coord| {
+                if coord >= field_size {
                     Some(-1.0)
-                } else if x < 0.0 {
+                } else if coord < 0.0 {
                     Some(1.0)
                 } else {
                     None

--- a/src/render_path.rs
+++ b/src/render_path.rs
@@ -2,6 +2,17 @@ use crate::game::{Asteroid, Bullet, Explosion, Game, InputIndex};
 use crate::math::Vec2D;
 use std::fmt::Write;
 
+fn draw(buf: &mut String, line: bool, point: Vec2D) {
+    write!(
+        buf,
+        "{}{:.2} {:.2} ",
+        if line { 'L' } else { 'M' },
+        point.x,
+        point.y
+    )
+    .expect("could not write string");
+}
+
 const SHIP_POINTS: &[Vec2D] = &[
     Vec2D { x: 10.0, y: 0.0 },
     Vec2D { x: -10.0, y: -5.0 },
@@ -24,15 +35,13 @@ fn render_ship(buf: &mut String, game: &Game) {
     }
     let inputs = &game.inputs;
     for (i, p) in SHIP_POINTS.iter().enumerate() {
-        let c = if i == 0 { 'M' } else { 'L' };
         let p_c = p.scale(2.0).rotate(ship.angle) + ship.pos;
-        write!(buf, "{}{:.2} {:.2} ", c, p_c.x, p_c.y).expect("could not write string?");
+        draw(buf, i != 0, p_c);
     }
     if inputs.is_down(InputIndex::Forward) || inputs.is_down(InputIndex::Backward) {
         for (i, p) in FLARE.iter().enumerate() {
-            let c = if i == 0 { 'M' } else { 'L' };
             let p_c = p.scale(2.0).rotate(ship.angle) + ship.pos;
-            write!(buf, "{}{:.2} {:.2} ", c, p_c.x, p_c.y).expect("could not write string?");
+            draw(buf, i != 0, p_c);
         }
     }
 }
@@ -41,12 +50,8 @@ fn render_bullet(buf: &mut String, bullet: &Bullet) {
     let offset = Vec2D::zero();
     let start = bullet.pos + offset;
     let end = bullet.pos + bullet.speed.normalize().scale(5.0);
-    write!(
-        buf,
-        "M{:.2} {:.2} L{:.2} {:.2} ",
-        start.x, start.y, end.x, end.y
-    )
-    .expect("could not write string?");
+    draw(buf, false, start);
+    draw(buf, true, end);
 }
 
 fn render_asteroid(buf: &mut String, asteroid: &Asteroid) {
@@ -56,9 +61,8 @@ fn render_asteroid(buf: &mut String, asteroid: &Asteroid) {
     let angle = std::f64::consts::PI * 2.0 / (cnt as f64);
     let one = Vec2D::one().scale(asteroid.size).rotate(asteroid.angle);
     for i in 0..(cnt + 1) {
-        let c = if i == 0 { 'M' } else { 'L' };
         let p = mid + one.rotate(angle * (i as f64));
-        write!(buf, "{}{:.2} {:.2}", c, p.x, p.y).expect("could not write string?");
+        draw(buf, i != 0, p);
     }
 }
 
@@ -69,9 +73,8 @@ fn render_lives(buf: &mut String, lives: u64) {
         let y = -50.0;
         let x = ((l + 1) as f64) * LIFE_STEP;
         for (i, p) in SHIP_POINTS.iter().enumerate() {
-            let c = if i == 0 { 'M' } else { 'L' };
             let p_c = p.scale(2.0).rotate(UP_ANGLE) + Vec2D { x, y };
-            write!(buf, "{}{:.2} {:.2} ", c, p_c.x, p_c.y).expect("could not write string?");
+            draw(buf, i != 0, p_c);
         }
     }
 }
@@ -90,12 +93,8 @@ fn render_explosion(buf: &mut String, explosion: &Explosion, tick: u64) {
         let start = dir.scale(state * EXPLOSION_RADIUS) + explosion.pos;
         let end = dir.scale(state * EXPLOSION_RADIUS + EXPLOSION_PARTICLE_LENGTH * (1.0 + state))
             + explosion.pos;
-        write!(
-            buf,
-            "M {:.2} {:.2} L {:.2} {:.2}",
-            start.x, start.y, end.x, end.y
-        )
-        .expect("could not write string?");
+        draw(buf, false, start);
+        draw(buf, true, end);
     }
 }
 
@@ -213,8 +212,7 @@ fn render_score(buf: &mut String, mut score: u64) {
                     x: DIGIT_RIGHTMOST + (idx as f64) * DIGIT_STEP,
                     y: -DIGIT_SCALE * 5.0,
                 };
-            let c = if i == 0 { 'M' } else { 'L' };
-            write!(buf, "{} {:.2} {:.2} ", c, p.x, p.y).expect("could not write string?");
+            draw(buf, i != 0, p);
         }
     }
 }

--- a/src/render_path.rs
+++ b/src/render_path.rs
@@ -23,41 +23,31 @@ fn draw_points(buf: &mut String, points: Vec<Vec2D>) {
     }
 }
 
+fn calculate_wrap(points: &Vec<Vec2D>, field_size: &Vec2D, x: bool) -> f64 {
+    let field_size = if x { field_size.x } else { field_size.y };
+    points
+        .iter()
+        .map(|point| if x { point.x } else { point.y })
+        .filter_map(|x| {
+            if x >= field_size {
+                Some(-1.0)
+            } else if x < 0.0 {
+                Some(1.0)
+            } else {
+                None
+            }
+        })
+        .nth(0)
+        .unwrap_or_default()
+}
+
 fn translate(points: &Vec<Vec2D>, translation: Vec2D) -> Vec<Vec2D> {
     points.iter().map(|&point| point + translation).collect()
 }
 
 fn draw_points_wrapping(buf: &mut String, points: Vec<Vec2D>, field_size: Vec2D) {
-    let x_wrap = points
-        .iter()
-        .map(|point| point.x)
-        .map(|x| {
-            if x >= field_size.x {
-                -1.0
-            } else if x < 0.0 {
-                1.0
-            } else {
-                0.0
-            }
-        })
-        .filter(|&wrap| wrap != 0.0)
-        .nth(0)
-        .unwrap_or_default();
-    let y_wrap = points
-        .iter()
-        .map(|point| point.y)
-        .map(|y| {
-            if y >= field_size.y {
-                -1.0
-            } else if y < 0.0 {
-                1.0
-            } else {
-                0.0
-            }
-        })
-        .filter(|&wrap| wrap != 0.0)
-        .nth(0)
-        .unwrap_or_default();
+    let x_wrap = calculate_wrap(&points, &field_size, true);
+    let y_wrap = calculate_wrap(&points, &field_size, false);
     if x_wrap != 0.0 {
         if y_wrap != 0.0 {
             let translated_points = translate(

--- a/src/render_path.rs
+++ b/src/render_path.rs
@@ -66,15 +66,20 @@ fn render_bullet(buf: &mut String, bullet: &Bullet) {
 }
 
 fn render_asteroid(buf: &mut String, asteroid: &Asteroid) {
-    let offset = Vec2D::zero();
-    let mid = asteroid.pos + offset;
     let cnt = asteroid.style;
-    let angle = std::f64::consts::PI * 2.0 / (cnt as f64);
-    let one = Vec2D::one().scale(asteroid.size).rotate(asteroid.angle);
-    for i in 0..(cnt + 1) {
-        let p = mid + one.rotate(angle * (i as f64));
-        draw(buf, i != 0, p);
-    }
+    let angle = std::f64::consts::TAU / (cnt as f64);
+    let asteroid_points = vec![Vec2D::one(); cnt + 1]
+        .iter()
+        .enumerate()
+        .map(|(i, v)| v.rotate(angle * (i as f64)))
+        .collect();
+    draw_object(
+        buf,
+        asteroid_points,
+        asteroid.size,
+        asteroid.angle,
+        asteroid.pos,
+    );
 }
 
 fn render_lives(buf: &mut String, lives: u64) {
@@ -104,8 +109,7 @@ fn render_explosion(buf: &mut String, explosion: &Explosion, tick: u64) {
         let start = dir.scale(state * EXPLOSION_RADIUS) + explosion.pos;
         let end = dir.scale(state * EXPLOSION_RADIUS + EXPLOSION_PARTICLE_LENGTH * (1.0 + state))
             + explosion.pos;
-        draw(buf, false, start);
-        draw(buf, true, end);
+        draw_points(buf, vec![start, end]);
     }
 }
 

--- a/src/render_path.rs
+++ b/src/render_path.rs
@@ -13,7 +13,7 @@ fn draw(buf: &mut String, line: bool, point: Vec2D) {
     .expect("could not write string");
 }
 
-fn draw_points(buf: &mut String, points: Vec<Vec2D>, _field_size: Vec2D) {
+fn draw_points(buf: &mut String, points: Vec<Vec2D>) {
     if points.is_empty() {
         return;
     }
@@ -27,14 +27,14 @@ fn translate(points: &Vec<Vec2D>, translation: Vec2D) -> Vec<Vec2D> {
     points.iter().map(|&point| point + translation).collect()
 }
 
-fn draw_points_wrapping(buf: &mut String, points: Vec<Vec2D>, _field_size: Vec2D) {
+fn draw_points_wrapping(buf: &mut String, points: Vec<Vec2D>, field_size: Vec2D) {
     let x_wrap = points
         .iter()
         .map(|point| point.x)
         .map(|x| {
-            if x >= _field_size.x {
+            if x >= field_size.x {
                 -1.0
-            } else if x < _field_size.x {
+            } else if x < field_size.x {
                 1.0
             } else {
                 0.0
@@ -47,9 +47,9 @@ fn draw_points_wrapping(buf: &mut String, points: Vec<Vec2D>, _field_size: Vec2D
         .iter()
         .map(|point| point.y)
         .map(|y| {
-            if y >= _field_size.y {
+            if y >= field_size.y {
                 -1.0
-            } else if y < _field_size.y {
+            } else if y < field_size.y {
                 1.0
             } else {
                 0.0
@@ -63,32 +63,32 @@ fn draw_points_wrapping(buf: &mut String, points: Vec<Vec2D>, _field_size: Vec2D
             let translated_points = translate(
                 &points,
                 Vec2D {
-                    x: _field_size.x * x_wrap,
-                    y: _field_size.y * y_wrap,
+                    x: field_size.x * x_wrap,
+                    y: field_size.y * y_wrap,
                 },
             );
-            draw_points(buf, translated_points, _field_size);
+            draw_points(buf, translated_points);
         }
         let translated_points = translate(
             &points,
             Vec2D {
-                x: _field_size.x * x_wrap,
+                x: field_size.x * x_wrap,
                 y: 0.0,
             },
         );
-        draw_points(buf, translated_points, _field_size);
+        draw_points(buf, translated_points);
     }
     if y_wrap != 0.0 {
         let translated_points = translate(
             &points,
             Vec2D {
                 x: 0.0,
-                y: _field_size.y * y_wrap,
+                y: field_size.y * y_wrap,
             },
         );
-        draw_points(buf, translated_points, _field_size);
+        draw_points(buf, translated_points);
     }
-    draw_points(buf, points, _field_size);
+    draw_points(buf, points);
 }
 
 fn draw_object(
@@ -99,7 +99,7 @@ fn draw_object(
     offset: Vec2D,
     field_size: Vec2D,
 ) {
-    draw_points(
+    draw_points_wrapping(
         buf,
         points
             .iter()
@@ -152,7 +152,7 @@ fn render_ship(buf: &mut String, game: &Game) {
 
 fn render_bullet(buf: &mut String, bullet: &Bullet, field_size: Vec2D) {
     let tail = bullet.pos + bullet.speed.normalize().scale(5.0);
-    draw_points(buf, vec![bullet.pos, tail], field_size);
+    draw_points_wrapping(buf, vec![bullet.pos, tail], field_size);
 }
 
 fn render_asteroid(buf: &mut String, asteroid: &Asteroid, field_size: Vec2D) {
@@ -204,7 +204,7 @@ fn render_explosion(buf: &mut String, explosion: &Explosion, tick: u64, field_si
         let start = dir.scale(state * EXPLOSION_RADIUS) + explosion.pos;
         let end = dir.scale(state * EXPLOSION_RADIUS + EXPLOSION_PARTICLE_LENGTH * (1.0 + state))
             + explosion.pos;
-        draw_points(buf, vec![start, end], field_size);
+        draw_points_wrapping(buf, vec![start, end], field_size);
     }
 }
 

--- a/src/render_path.rs
+++ b/src/render_path.rs
@@ -34,7 +34,7 @@ fn draw_points_wrapping(buf: &mut String, points: Vec<Vec2D>, field_size: Vec2D)
         .map(|x| {
             if x >= field_size.x {
                 -1.0
-            } else if x < field_size.x {
+            } else if x < 0.0 {
                 1.0
             } else {
                 0.0
@@ -49,7 +49,7 @@ fn draw_points_wrapping(buf: &mut String, points: Vec<Vec2D>, field_size: Vec2D)
         .map(|y| {
             if y >= field_size.y {
                 -1.0
-            } else if y < field_size.y {
+            } else if y < 0.0 {
                 1.0
             } else {
                 0.0

--- a/src/render_path.rs
+++ b/src/render_path.rs
@@ -23,6 +23,16 @@ fn draw_points(buf: &mut String, points: Vec<Vec2D>) {
     }
 }
 
+fn draw_object(buf: &mut String, points: Vec<Vec2D>, scale: f64, rotation: f64, offset: Vec2D) {
+    draw_points(
+        buf,
+        points
+            .iter()
+            .map(|p| p.scale(scale).rotate(rotation) + offset)
+            .collect(),
+    );
+}
+
 const SHIP_POINTS: &[Vec2D] = &[
     Vec2D { x: 10.0, y: 0.0 },
     Vec2D { x: -10.0, y: -5.0 },

--- a/src/render_path.rs
+++ b/src/render_path.rs
@@ -88,10 +88,7 @@ fn render_lives(buf: &mut String, lives: u64) {
     for l in 0..lives {
         let y = -50.0;
         let x = ((l + 1) as f64) * LIFE_STEP;
-        for (i, p) in SHIP_POINTS.iter().enumerate() {
-            let p_c = p.scale(2.0).rotate(UP_ANGLE) + Vec2D { x, y };
-            draw(buf, i != 0, p_c);
-        }
+        draw_object(buf, SHIP_POINTS.to_vec(), 2.0, UP_ANGLE, Vec2D { x, y });
     }
 }
 

--- a/static/index.html
+++ b/static/index.html
@@ -8,7 +8,7 @@
   }
 </style>
 <svg width="1280" height="820">
-  <g transform="translate(0, 100)">
+  <g>
     <path id="path"></path>
   </g>
 </svg>


### PR DESCRIPTION
This PR introduces wrapping graphics for all in-game objects:
![image](https://user-images.githubusercontent.com/45777186/187047584-f9996ddb-f16d-45de-9588-e9b91b51c3ec.png)
Additionally, `render_path.rs` was heavily refactored to make updating the drawing code easier in the future.